### PR TITLE
Fixes issue where DTGE breaks if numbers (integers) aren't passed as strings

### DIFF
--- a/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.controllers.js
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.controllers.js
@@ -192,6 +192,23 @@ angular.module("umbraco").controller("Our.Umbraco.DocTypeGridEditor.Dialogs.DocT
                 }
             };
 
+            // this method will ensure that number values in nested/complex property editors 
+            // will be turned into string to emulate how the core handles values     
+            function deNumberValues(propValue) {
+                if (Array.isArray(propValue)) {
+                    propValue.forEach(function (key, index) {
+                        propValue[index] = deNumberValues(propValue[index]);
+                    });
+                } else {
+                    Object.keys(propValue).forEach(function (key, index) {
+                        if (propValue[key] === parseInt(propValue[key])) {
+                            propValue[key] = propValue[key].toString();
+                        }
+                    });
+                }
+                return propValue;
+            }
+
             function loadNode() {
                 contentResource.getScaffold(-20, $scope.dialogData.docTypeAlias).then(function (data) {
                     // Remove the last tab
@@ -204,7 +221,7 @@ angular.module("umbraco").controller("Our.Umbraco.DocTypeGridEditor.Dialogs.DocT
                             for (var p = 0; p < tab.properties.length; p++) {
                                 var prop = tab.properties[p];
                                 if ($scope.dialogData.value[prop.alias]) {
-                                    prop.value = $scope.dialogData.value[prop.alias];
+                                    prop.value = deNumberValues($scope.dialogData.value[prop.alias]);
                                 }
                             }
                         }


### PR DESCRIPTION
Edge case fix that'll ensure that number values becomes strings when send to the DTGE dialog window.

When Umbraco sends value to editors such as pickers it'll pass them as strings. When DTGE stores values it'll stringify them. In edge cases such as when data is transfered between environments with Courier/Deploy nested items is parsed in a ("correct") way so that they end up not being strings on the target environment (thus saved as Umbraco would save them). It causes these editors to break.