### PR TITLE
use umb-editor-placeholder instead of acient 'usky'

### DIFF
--- a/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Views/doctypegrideditor.html
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Views/doctypegrideditor.html
@@ -1,5 +1,5 @@
 ﻿<div ng-controller="Our.Umbraco.DocTypeGridEditor.GridEditors.DocTypeGridEditor">
-    <div class="usky-editor-placeholder dtge-editor-placeholder"
+    <div class="umb-editor-placeholder dtge-editor-placeholder"
          ng-click="setDocType()"
          ng-class="{ 'dtge-editor-placeholder--preview' : preview }">
         <div ng-if="!preview">


### PR DESCRIPTION
This creates 'large' blocks in the grid