### PR TITLE
Enables media tracking in 8.6

### DIFF
--- a/src/Our.Umbraco.DocTypeGridEditor/Composing/DocTypeGridEditorComposer.cs
+++ b/src/Our.Umbraco.DocTypeGridEditor/Composing/DocTypeGridEditorComposer.cs
@@ -1,5 +1,6 @@
 ﻿using Our.Umbraco.DocTypeGridEditor.Extensions;
 using Our.Umbraco.DocTypeGridEditor.ValueProcessing;
+using Umbraco.Core;
 using Umbraco.Core.Composing;
 
 namespace Our.Umbraco.DocTypeGridEditor.Composing
@@ -12,6 +13,7 @@ namespace Our.Umbraco.DocTypeGridEditor.Composing
         public void Compose(Composition composition)
         {
             composition.DocTypeGridEditorValueProcessors().Append<UmbracoTagsValueProcessor>();
+            composition.DataValueReferenceFactories().Append<DocTypeGridEditorDataValueReference>();
         }
     }
 }

--- a/src/Our.Umbraco.DocTypeGridEditor/Models/DocTypeGridEditorValue.cs
+++ b/src/Our.Umbraco.DocTypeGridEditor/Models/DocTypeGridEditorValue.cs
@@ -1,0 +1,20 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Our.Umbraco.DocTypeGridEditor.Models
+{
+    public class DocTypeGridEditorValue
+    {
+        [JsonProperty("value")]
+        public JObject Value { get; set; }
+        [JsonProperty("dtgeContentTypeAlias")]
+        public string ContentTypeAlias { get; set; }
+        [JsonProperty("id")]
+        public Guid Id { get; set; }
+    }
+}

--- a/src/Our.Umbraco.DocTypeGridEditor/Our.Umbraco.DocTypeGridEditor.csproj
+++ b/src/Our.Umbraco.DocTypeGridEditor/Our.Umbraco.DocTypeGridEditor.csproj
@@ -35,11 +35,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="ClientDependency.Core, Version=1.9.9.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ClientDependency.1.9.9\lib\net45\ClientDependency.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="ClientDependency.Core.Mvc, Version=1.9.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ClientDependency-Mvc5.1.9.3\lib\net45\ClientDependency.Core.Mvc.dll</HintPath>
+    </Reference>
     <Reference Include="CSharpTest.Net.Collections, Version=14.906.1403.1082, Culture=neutral, PublicKeyToken=06aee00cce822474, processorArchitecture=MSIL">
       <HintPath>..\packages\CSharpTest.Net.Collections.14.906.1403.1082\lib\net40\CSharpTest.Net.Collections.dll</HintPath>
     </Reference>
-    <Reference Include="Examine, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Examine.1.0.0\lib\net452\Examine.dll</HintPath>
+    <Reference Include="Examine, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Examine.1.0.2\lib\net452\Examine.dll</HintPath>
     </Reference>
     <Reference Include="HtmlAgilityPack, Version=1.8.14.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
       <HintPath>..\packages\HtmlAgilityPack.1.8.14\lib\Net45\HtmlAgilityPack.dll</HintPath>
@@ -206,16 +212,19 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Umbraco.Core, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UmbracoCms.Core.8.1.0\lib\net472\Umbraco.Core.dll</HintPath>
+      <HintPath>..\packages\UmbracoCms.Core.8.6.0\lib\net472\Umbraco.Core.dll</HintPath>
     </Reference>
     <Reference Include="Umbraco.Examine, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UmbracoCms.Web.8.1.0\lib\net472\Umbraco.Examine.dll</HintPath>
+      <HintPath>..\packages\UmbracoCms.Web.8.6.0\lib\net472\Umbraco.Examine.dll</HintPath>
+    </Reference>
+    <Reference Include="Umbraco.ModelsBuilder.Embedded, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Web.8.6.0\lib\net472\Umbraco.ModelsBuilder.Embedded.dll</HintPath>
     </Reference>
     <Reference Include="Umbraco.Web, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UmbracoCms.Web.8.1.0\lib\net472\Umbraco.Web.dll</HintPath>
+      <HintPath>..\packages\UmbracoCms.Web.8.6.0\lib\net472\Umbraco.Web.dll</HintPath>
     </Reference>
     <Reference Include="Umbraco.Web.UI, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UmbracoCms.Web.8.1.0\lib\net472\Umbraco.Web.UI.dll</HintPath>
+      <HintPath>..\packages\UmbracoCms.Web.8.6.0\lib\net472\Umbraco.Web.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Our.Umbraco.DocTypeGridEditor/Our.Umbraco.DocTypeGridEditor.csproj
+++ b/src/Our.Umbraco.DocTypeGridEditor/Our.Umbraco.DocTypeGridEditor.csproj
@@ -230,6 +230,8 @@
   <ItemGroup>
     <Compile Include="Bootstrap.cs" />
     <Compile Include="Composing\Current.cs" />
+    <Compile Include="Models\DocTypeGridEditorValue.cs" />
+    <Compile Include="ValueProcessing\DocTypeGridEditorDataValueReference.cs" />
     <Compile Include="Extensions\JsonExtensions.cs" />
     <Compile Include="Helpers\DocTypeGridEditorHelper.cs" />
     <Compile Include="Helpers\XmlHelper.cs" />

--- a/src/Our.Umbraco.DocTypeGridEditor/ValueProcessing/DocTypeGridEditorDataValueReference.cs
+++ b/src/Our.Umbraco.DocTypeGridEditor/ValueProcessing/DocTypeGridEditorDataValueReference.cs
@@ -1,0 +1,74 @@
+﻿using Newtonsoft.Json;
+using Our.Umbraco.DocTypeGridEditor.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Umbraco.Core;
+using Umbraco.Core.Composing;
+using Umbraco.Core.Models;
+using Umbraco.Core.Models.Editors;
+using Umbraco.Core.PropertyEditors;
+
+namespace Our.Umbraco.DocTypeGridEditor.ValueProcessing
+{
+    public class DocTypeGridEditorDataValueReference : IDataValueReferenceFactory, IDataValueReference
+    {
+        private readonly Lazy<Dictionary<string, IContentType>> _contentTypes;
+
+        public IDataValueReference GetDataValueReference() => this;
+
+        public bool IsForEditor(IDataEditor dataEditor) => dataEditor.Alias.InvariantEquals(Constants.PropertyEditors.Aliases.Grid);
+
+
+        public DocTypeGridEditorDataValueReference()
+        {
+            _contentTypes = new Lazy<Dictionary<string, IContentType>>(() => Current.Services.ContentTypeService.GetAll().ToDictionary(c => c.Alias));
+        }
+
+        public IEnumerable<UmbracoEntityReference> GetReferences(object value)
+        {
+            var result = new List<UmbracoEntityReference>();
+            var _propertyEditors = Current.PropertyEditors;
+            var rawJson = value == null ? string.Empty : value is string str ? str : value.ToString();
+            DeserializeGridValue(rawJson, out var dtgeValues);
+
+            foreach (var control in dtgeValues)
+            {
+                if (_contentTypes.Value.TryGetValue(control.ContentTypeAlias, out var contentType))
+                {
+                    var propertyTypes = contentType.CompositionPropertyTypes.ToDictionary(x => x.Alias, x => x);
+                    var properties = control.Value.Properties();
+
+                    foreach (var property in properties)
+                    {
+                        if (propertyTypes.TryGetValue(property.Name, out var propertyType))
+                        {
+                            if (_propertyEditors.TryGet(propertyType.PropertyEditorAlias, out var propertyEditor))
+                            {
+                                if (propertyEditor.GetValueEditor() is IDataValueReference reference)
+                                {
+                                    var propertyValue = property.Value.ToString();
+                                    var refs = reference.GetReferences(propertyValue);
+                                    result.AddRange(refs);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            return result;
+
+        }
+
+        internal GridValue DeserializeGridValue(string rawJson, out IEnumerable<DocTypeGridEditorValue> dtgeValues)
+        {
+            var grid = JsonConvert.DeserializeObject<GridValue>(rawJson);
+
+            // Find all controls that uses DTGE editor
+            var controls = grid.Sections.SelectMany(x => x.Rows.SelectMany(r => r.Areas).SelectMany(a => a.Controls)).ToArray();
+            dtgeValues = controls.Where(x => x.Editor.Alias.ToLowerInvariant() == "doctype").Select(x => x.Value.ToObject<DocTypeGridEditorValue>());
+
+            return grid;
+        }
+    }
+}

--- a/src/Our.Umbraco.DocTypeGridEditor/packages.config
+++ b/src/Our.Umbraco.DocTypeGridEditor/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ClientDependency" version="1.9.7" targetFramework="net45" />
+  <package id="ClientDependency" version="1.9.9" targetFramework="net472" />
   <package id="ClientDependency-Mvc" version="1.8.0.0" targetFramework="net45" />
-  <package id="ClientDependency-Mvc5" version="1.8.0.0" targetFramework="net45" />
+  <package id="ClientDependency-Mvc5" version="1.9.3" targetFramework="net472" />
   <package id="CSharpTest.Net.Collections" version="14.906.1403.1082" targetFramework="net472" />
-  <package id="Examine" version="1.0.0" targetFramework="net472" />
+  <package id="Examine" version="1.0.2" targetFramework="net472" />
   <package id="HtmlAgilityPack" version="1.8.14" targetFramework="net472" />
   <package id="ImageProcessor" version="2.7.0.100" targetFramework="net472" />
   <package id="ImageProcessor.Web" version="4.8.3" targetFramework="net45" />
@@ -65,8 +65,8 @@
   <package id="System.Threading.Tasks.Dataflow" version="4.9.0" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
   <package id="Umbraco.SqlServerCE" version="4.0.0.1" targetFramework="net472" />
-  <package id="UmbracoCms.Core" version="8.1.0" targetFramework="net472" />
-  <package id="UmbracoCms.Web" version="8.1.0" targetFramework="net472" />
+  <package id="UmbracoCms.Core" version="8.6.0" targetFramework="net472" />
+  <package id="UmbracoCms.Web" version="8.6.0" targetFramework="net472" />
   <package id="UrlRewritingNet" version="2.0.7" targetFramework="net45" />
   <package id="xmlrpcnet" version="2.5.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
So, this enables the new media tracking feature (it actually also tracks content usage, so Core must be preparing for this).

Anyone wants to take this for at spin, to see if I missed anything?

I would also appreciate a review of the code, was hacking away and got it working now :)

The code is based of @warrenbuckley s [example ](https://github.com/umbraco/Umbraco-CMS/pull/7228#issuecomment-562098627)  and the existing `IDataValueReference` for [grid](https://github.com/umbraco/Umbraco-CMS/blob/c63af8e1619a92b462b2c053019a99e799574a3d/src/Umbraco.Web/PropertyEditors/GridPropertyEditor.cs#L71) and [nested content](https://github.com/umbraco/Umbraco-CMS/blob/a9d45413c89d67280ce54c7fd4182e90323bab6c/src/Umbraco.Web/PropertyEditors/NestedContentPropertyEditor.cs#L57) (because NC's datamodel is quite similar to DTGEs.

Obiously this would bump the minimum required version to 8.6 - would like some input on that as well :)

Happy easter everyone 🐣