### PR TITLE
Initial draft of fix for #194 database hits

### DIFF
--- a/src/Our.Umbraco.DocTypeGridEditor/Composing/DocTypeGridEditorComposer.cs
+++ b/src/Our.Umbraco.DocTypeGridEditor/Composing/DocTypeGridEditorComposer.cs
@@ -1,7 +1,11 @@
 ﻿using Our.Umbraco.DocTypeGridEditor.Extensions;
 using Our.Umbraco.DocTypeGridEditor.ValueProcessing;
 using Umbraco.Core;
+using Umbraco.Core.Cache;
 using Umbraco.Core.Composing;
+using Umbraco.Core.Events;
+using Umbraco.Core.Services;
+using Umbraco.Core.Services.Implement;
 
 namespace Our.Umbraco.DocTypeGridEditor.Composing
 {
@@ -14,6 +18,36 @@ namespace Our.Umbraco.DocTypeGridEditor.Composing
         {
             composition.DocTypeGridEditorValueProcessors().Append<UmbracoTagsValueProcessor>();
             composition.DataValueReferenceFactories().Append<DocTypeGridEditorDataValueReference>();
+            composition.Components().Append<DocTypeGridEditorCacheResetComponent>();
         }
     }
+
+    public class DocTypeGridEditorCacheResetComponent : IComponent
+    {
+        private IAppPolicyCache _runtimeCache;
+
+        public DocTypeGridEditorCacheResetComponent(AppCaches caches)
+        {
+            _runtimeCache = caches.RuntimeCache;
+        }
+
+        public void Initialize()
+        {
+            ContentService.Published += ContentServiceOnPublished;
+        }
+
+        private void ContentServiceOnPublished(IContentService sender, ContentPublishedEventArgs e)
+        {
+            foreach (var content in e.PublishedEntities)
+            {
+                _runtimeCache.ClearByKey($"Our.Umbraco.DocTypeGridEditor.Helpers.DocTypeGridEditorHelper.ConvertValueToContent_Page_{content.Id}");
+            }
+        }
+
+        public void Terminate()
+        {
+            
+        }
+    }
+
 }

--- a/src/Our.Umbraco.DocTypeGridEditor/Helpers/DocTypeGridEditorHelper.cs
+++ b/src/Our.Umbraco.DocTypeGridEditor/Helpers/DocTypeGridEditorHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Web.Caching;
 using System.Web.Mvc;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -37,7 +38,11 @@ namespace Our.Umbraco.DocTypeGridEditor.Helpers
                 () =>
                 {
                     return ConvertValue(id, contentTypeAlias, dataJson);
-                });
+                },
+                timeout: TimeSpan.FromMinutes(120),
+                isSliding:true,
+                CacheItemPriority.BelowNormal
+            );
         }
 
         public static IPublishedElement ConvertValueToContent(string id, string contentTypeAlias, string dataJson)

--- a/src/Our.Umbraco.DocTypeGridEditor/Helpers/DocTypeGridEditorHelper.cs
+++ b/src/Our.Umbraco.DocTypeGridEditor/Helpers/DocTypeGridEditorHelper.cs
@@ -21,6 +21,25 @@ namespace Our.Umbraco.DocTypeGridEditor.Helpers
     public static class DocTypeGridEditorHelper
     {
 
+        public static IPublishedElement ConvertValueToContent(string id, string contentTypeAlias, string dataJson, int pageId)
+        {
+            if (string.IsNullOrWhiteSpace(contentTypeAlias))
+                return null;
+
+            if (dataJson == null)
+                return null;
+
+            if (Current.UmbracoContext == null)
+                return ConvertValue(id, contentTypeAlias, dataJson);
+            
+            return (IPublishedElement)Current.AppCaches.RuntimeCache.GetCacheItem(
+                $"Our.Umbraco.DocTypeGridEditor.Helpers.DocTypeGridEditorHelper.ConvertValueToContent_Page_{pageId}_{id}_{contentTypeAlias}",
+                () =>
+                {
+                    return ConvertValue(id, contentTypeAlias, dataJson);
+                });
+        }
+
         public static IPublishedElement ConvertValueToContent(string id, string contentTypeAlias, string dataJson)
         {
             if (string.IsNullOrWhiteSpace(contentTypeAlias))
@@ -56,10 +75,10 @@ namespace Our.Umbraco.DocTypeGridEditor.Helpers
 
 
                 /* Because we never store the value in the database, we never run the property editors
-                     * "ConvertEditorToDb" method however the property editors will expect their value to 
-                     * be in a "DB" state so to get round this, we run the "ConvertEditorToDb" here before
-                     * we go on to convert the value for the view. 
-                     */
+                 * "ConvertEditorToDb" method however the property editors will expect their value to 
+                 * be in a "DB" state so to get round this, we run the "ConvertEditorToDb" here before
+                 * we go on to convert the value for the view. 
+                 */
                 Current.PropertyEditors.TryGet(propType.EditorAlias, out var propEditor);
                 var propPreValues = GetPreValuesCollectionByDataTypeId(propType.DataType.Id);
 

--- a/src/Our.Umbraco.DocTypeGridEditor/Web/Controllers/DocTypeGridEditorApiController.cs
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/Controllers/DocTypeGridEditorApiController.cs
@@ -171,8 +171,17 @@ namespace Our.Umbraco.DocTypeGridEditor.Web.Controllers
                 }
             }
 
+            IPublishedElement content;
             // Get content node object
-            var content = DocTypeGridEditorHelper.ConvertValueToContent(data.Id, data.ContentTypeAlias, data.Value);
+            if (page != null)
+            {
+                content = DocTypeGridEditorHelper.ConvertValueToContent(data.Id, data.ContentTypeAlias, data.Value,page.Id);
+            }
+            else
+            {
+                content = DocTypeGridEditorHelper.ConvertValueToContent(data.Id, data.ContentTypeAlias, data.Value);
+            }
+            
 
             // Construct preview model
             var model = new PreviewModel

--- a/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Render/DocTypeGridEditor.cshtml
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Render/DocTypeGridEditor.cshtml
@@ -3,6 +3,7 @@
 @using Microsoft.CSharp.RuntimeBinder
 @using Our.Umbraco.DocTypeGridEditor.Helpers
 @using Our.Umbraco.DocTypeGridEditor.Web.Extensions
+@using Umbraco.Core.Models.PublishedContent
 @inherits Umbraco.Web.Mvc.UmbracoViewPage<dynamic>
 @if (Model.value != null)
 {
@@ -11,6 +12,8 @@
     string contentTypeAlias = "";
     string value = Model.value.value.ToString();
     string viewPath = Model.editor.config.viewPath.ToString();
+
+    var page = UmbracoContext.PublishedRequest.PublishedContent;
 
     try
     {
@@ -23,7 +26,17 @@
 
     if (contentTypeAlias != "")
     {
-        var content = DocTypeGridEditorHelper.ConvertValueToContent(id, contentTypeAlias, value);
+        IPublishedElement content;
+
+        if (page != null)
+        {
+            content = DocTypeGridEditorHelper.ConvertValueToContent(id, contentTypeAlias, value, page.Id);
+        }
+        else
+        {
+            content = DocTypeGridEditorHelper.ConvertValueToContent(id, contentTypeAlias, value);
+        }
+        
 
         @Html.RenderDocTypeGridEditorItem(content, editorAlias, viewPath)
     }

--- a/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Render/DocTypeGridEditor.cshtml
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Render/DocTypeGridEditor.cshtml
@@ -28,7 +28,7 @@
     {
         IPublishedElement content;
 
-        if (page != null)
+        if (page != null && UmbracoContext.InPreviewMode == false)
         {
             content = DocTypeGridEditorHelper.ConvertValueToContent(id, contentTypeAlias, value, page.Id);
         }


### PR DESCRIPTION
I think that this might work, but of course needs som refactoring.

Basicly I just added a overload to the ConvertValueToContent that also can take the current PageId, it would store the result in the Runtime cache and reset this when something is published for that node id.

What do you think? Is this in the right direction? I saw a huge performance boost when testing it.

The only thing that "worries" me is if this might fill up the runtime cache in any way... maybe we should have some kind of time out for the item in the cache, not sure what that would be.