### PR TITLE
Fix for unsaved changes dialog on new pages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 image: Visual Studio 2017
 
 # version format
-version: 1.2.2.{build}
+version: 1.2.3.{build}
 
 # UMBRACO_PACKAGE_PRERELEASE_SUFFIX if a rtm release build this should be blank, otherwise if empty will default to alpha
 # example UMBRACO_PACKAGE_PRERELEASE_SUFFIX=beta

--- a/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Css/doctypegrideditor.css
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Css/doctypegrideditor.css
@@ -44,3 +44,11 @@
     display: block;
 }
 */
+
+/* workaround for https://github.com/skttl/umbraco-doc-type-grid-editor/issues/199 from https://github.com/umbraco/Umbraco-CMS/issues/7754 */
+body.pre870 .dtge-dialog .umb-overlay {
+    left: inherit !important;
+    right: 0 !important;
+    top: 0 !important;
+    bottom: 0 !important;
+}

--- a/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.controllers.js
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.controllers.js
@@ -387,6 +387,10 @@ angular.module("umbraco").controller("Our.Umbraco.DocTypeGridEditor.Dialogs.DocT
                 });
             }
 
+            if (dtgeUtilityService.compareCurrentUmbracoVersion("8.7.0", {}) && !$("body").hasClass("pre870")) {
+                $("body").addClass("pre870");
+            };
+
         }
 
     ]);


### PR DESCRIPTION
Fix for #205 
When a DTGE-editor is added to a new created page and the serverside validation fails, the dialog for unsaved changes pops up.
This fix captures the $routeParams.create values, resets it and sets it back after saving.