### PR TITLE
Fix for unsaved changes dialog on new pages

### DIFF
--- a/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.controllers.js
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.controllers.js
@@ -1,4 +1,4 @@
-﻿angular.module("umbraco").controller("Our.Umbraco.DocTypeGridEditor.GridEditors.DocTypeGridEditor", [
+angular.module("umbraco").controller("Our.Umbraco.DocTypeGridEditor.GridEditors.DocTypeGridEditor", [
 
     "$scope",
     "$rootScope",
@@ -239,8 +239,9 @@ angular.module("umbraco").controller("Our.Umbraco.DocTypeGridEditor.Dialogs.DocT
         "blueprintConfig",
         "contentEditingHelper",
         "serverValidationManager",
+        "$routeParams",
 
-        function ($scope, $interpolate, formHelper, contentResource, dtgeResources, dtgeUtilityService, blueprintConfig, contentEditingHelper, serverValidationManager) {
+        function ($scope, $interpolate, formHelper, contentResource, dtgeResources, dtgeUtilityService, blueprintConfig, contentEditingHelper, serverValidationManager, $routeParams) {
 
             var vm = this;
             vm.submit = submit;
@@ -269,6 +270,10 @@ angular.module("umbraco").controller("Our.Umbraco.DocTypeGridEditor.Dialogs.DocT
                     $scope.model.node.variants[0].name = $scope.model.node.name
                     $scope.model.node.variants[0].save = true;
 
+                    // Reset route create to prevent showing up the changed content dialog
+                    var routeParamsCreate = $routeParams.create;
+                    $routeParams.create = undefined;
+
                     // save the content as a blueprint, to trigger validation
                     var args = {
                         saveMethod: contentResource.saveBlueprint,
@@ -282,10 +287,14 @@ angular.module("umbraco").controller("Our.Umbraco.DocTypeGridEditor.Dialogs.DocT
 
                     contentEditingHelper.contentEditorPerformSave(args).then(function (data) {
                         $scope.model.submit($scope.model);
+                        // Reset original value of $routeParams.create
+                        $routeParams.create = routeParamsCreate;
                     },
-                    function (err) {
-                        // cleanup the blueprint immediately
-                        cleanup();
+                        function (err) {
+                            // Set original value of $routeParams.create
+                            $routeParams.create = routeParamsCreate;
+                            // cleanup the blueprint immediately
+                            cleanup();
                     });
                 }
             }


### PR DESCRIPTION
Fix for #205 
When a DTGE-editor is added to a new created page and the serverside validation fails, the dialog for unsaved changes pops up.
This fix captures the $routeParams.create values, resets it and sets it back after saving.