### PR TITLE
Resetting saveButtonState when validation contains errors

### DIFF
--- a/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.controllers.js
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.controllers.js
@@ -297,7 +297,7 @@ angular.module("umbraco").controller("Our.Umbraco.DocTypeGridEditor.Dialogs.DocT
                             $routeParams.create = routeParamsCreate;
                             // cleanup the blueprint immediately
                             cleanup();
-                            vm.saveButtonState = "init";
+                            vm.saveButtonState = "error";
                     });
                 }
             }

--- a/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.controllers.js
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.controllers.js
@@ -293,6 +293,7 @@ angular.module("umbraco").controller("Our.Umbraco.DocTypeGridEditor.Dialogs.DocT
                         $routeParams.create = routeParamsCreate;
                     },
                         function (err) {
+                            vm.saveButtonState = "init";
                             // Set original value of $routeParams.create
                             $routeParams.create = routeParamsCreate;
                             // cleanup the blueprint immediately


### PR DESCRIPTION
When the validation has errors, the saveButtonState should be reset to able to submit the form again.