### PR TITLE
Fixes issue when previewing linked content items

### DIFF
--- a/src/Our.Umbraco.DocTypeGridEditor/Web/Controllers/DocTypeGridEditorApiController.cs
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/Controllers/DocTypeGridEditorApiController.cs
@@ -31,7 +31,7 @@ namespace Our.Umbraco.DocTypeGridEditor.Web.Controllers
         private readonly IContentTypeService _contentTypeService;
         private readonly IDataTypeService _dataTypeService;
         private readonly IPublishedContentCache _contentCache;
-
+        
         public DocTypeGridEditorApiController()
         {
         }
@@ -157,7 +157,7 @@ namespace Our.Umbraco.DocTypeGridEditor.Web.Controllers
                 UmbracoContext.PublishedRequest = router.CreateRequest(UmbracoContext, Request.RequestUri);
                 UmbracoContext.PublishedRequest.PublishedContent = page;
             }
-
+            
             // Set the culture for the preview
             if (page != null && page.Cultures != null)
             {
@@ -168,6 +168,7 @@ namespace Our.Umbraco.DocTypeGridEditor.Web.Controllers
                     UmbracoContext.PublishedRequest.Culture = culture;
                     System.Threading.Thread.CurrentThread.CurrentCulture = culture;
                     System.Threading.Thread.CurrentThread.CurrentUICulture = culture;
+                    UmbracoContext.VariationContextAccessor.VariationContext = new VariationContext(culture.Name);
                 }
             }
 


### PR DESCRIPTION
Had previews failing to match up the content when, using a Multi node picker on the grid block to select its content that is rendered. This is how we are creating reusable blocks, so no content would show on a preview.

Setting the variation context resolved this.