### PR TITLE
Added form-horizontal class to fix label overlap

### DIFF
--- a/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Views/doctypegrideditor.dialog.html
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Views/doctypegrideditor.dialog.html
@@ -91,7 +91,9 @@
                     </umb-box>
                 </div>
                 <ng-form val-form-manager ng-switch-when="edit">
-                    <umb-tabbed-content content="vm.content"></umb-tabbed-content>
+                    <div class="form-horizontal">
+                        <umb-tabbed-content content="vm.content"></umb-tabbed-content>
+                    </div>
                 </ng-form>
             </div>
 


### PR DESCRIPTION
Added wrapper div with form-horizontal class to fix label overlap.

Before:
![image](https://user-images.githubusercontent.com/9937803/103879750-2ccd3e00-50d0-11eb-928c-8746d90540ef.png)

After:
![image](https://user-images.githubusercontent.com/9937803/103879797-36ef3c80-50d0-11eb-8a15-81a9fa03e63b.png)

resolves #232 