### PR TITLE
Null-check for err object when submiting

### DIFF
--- a/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.controllers.js
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.controllers.js
@@ -297,7 +297,9 @@ angular.module("umbraco").controller("Our.Umbraco.DocTypeGridEditor.Dialogs.DocT
                             // Set original value of $routeParams.create
                             $routeParams.create = routeParamsCreate;
                             // cleanup the blueprint immediately
-                            $scope.model.node.id = err.data.id;
+                            if (err && err.data) {
+                                $scope.model.node.id = err.data.id;
+                            }
                             cleanup();
                             vm.saveButtonState = "error";
                     });


### PR DESCRIPTION
When the clientside validation is done and it contains validation errors, the err object is null. Added an if statement to check if err is not null.