### PR TITLE
Reset save button explicitly. Fixes #231

### DIFF
--- a/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.controllers.js
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.controllers.js
@@ -301,6 +301,7 @@ angular.module("umbraco").controller("Our.Umbraco.DocTypeGridEditor.Dialogs.DocT
                             cleanup();
                             vm.saveButtonState = "error";
                     });
+                    vm.saveButtonState = "init";
                 }
             }
             function close() {


### PR DESCRIPTION
Pragmatic fix on dtge's end for issue with save button spinning forever after validation error on DT that has nested content properties. #231 