### PR TITLE
Supporting rc002 breaking changes.

### DIFF
--- a/src/Our.Umbraco.DocTypeGridEditor/Controllers/DocTypeGridEditorApiController.cs
+++ b/src/Our.Umbraco.DocTypeGridEditor/Controllers/DocTypeGridEditorApiController.cs
@@ -27,6 +27,7 @@ namespace Our.Umbraco.DocTypeGridEditor.Controllers
     public class DocTypeGridEditorApiController : UmbracoAuthorizedJsonController
     {
         private readonly IUmbracoContextAccessor _umbracoContext;
+        private readonly IVariationContextAccessor _variationContextAccessor;
         private readonly IContentTypeService _contentTypeService;
         private readonly IContentService _contentService;
         private readonly IDataTypeService _dataTypeService;
@@ -39,6 +40,7 @@ namespace Our.Umbraco.DocTypeGridEditor.Controllers
         private readonly PropertyEditorCollection _propertyEditorCollection;
 
         public DocTypeGridEditorApiController(IUmbracoContextAccessor umbracoContext,
+            IVariationContextAccessor variationContextAccessor,
             IContentTypeService contentTypeService,
             IContentService contentService,
             IDataTypeService dataTypeService,
@@ -51,6 +53,7 @@ namespace Our.Umbraco.DocTypeGridEditor.Controllers
             DocTypeGridEditorHelper dtgeHelper)
         {
             _umbracoContext = umbracoContext;
+            _variationContextAccessor = variationContextAccessor;
             _contentTypeService = contentTypeService;
             _contentService = contentService;
             _dataTypeService = dataTypeService;
@@ -168,11 +171,11 @@ namespace Our.Umbraco.DocTypeGridEditor.Controllers
             }
 
 
-            if (_umbracoContext.UmbracoContext.PublishedRequest == null)
+            if (_umbracoContext.GetRequiredUmbracoContext().PublishedRequest == null)
             {
                 var request = _router.CreateRequestAsync(new Uri(Request.GetDisplayUrl())).Result;
                 request.SetPublishedContent(page);
-                _umbracoContext.UmbracoContext.PublishedRequest = request.Build();
+                _umbracoContext.GetRequiredUmbracoContext().PublishedRequest = request.Build();
             }
 
             // Set the culture for the preview
@@ -184,7 +187,7 @@ namespace Our.Umbraco.DocTypeGridEditor.Controllers
                     var culture = new CultureInfo(page.Cultures[currentCulture].Culture);
                     System.Threading.Thread.CurrentThread.CurrentCulture = culture;
                     System.Threading.Thread.CurrentThread.CurrentUICulture = culture;
-                    _umbracoContext.UmbracoContext.VariationContextAccessor.VariationContext = new VariationContext(culture.Name);
+                    _variationContextAccessor.VariationContext = new VariationContext(culture.Name);
                 }
             }
 

--- a/src/Our.Umbraco.DocTypeGridEditor/Helpers/DocTypeGridEditorHelper.cs
+++ b/src/Our.Umbraco.DocTypeGridEditor/Helpers/DocTypeGridEditorHelper.cs
@@ -74,7 +74,7 @@ namespace Our.Umbraco.DocTypeGridEditor.Helpers
             if (dataJson == null)
                 return null;
 
-            if (_umbracoContext.UmbracoContext == null)
+            if (_umbracoContext.GetRequiredUmbracoContext() == null)
                 return ConvertValue(id, contentTypeAlias, dataJson);
 
             return (IPublishedElement)_appCaches.RequestCache.Get(
@@ -155,7 +155,7 @@ namespace Our.Umbraco.DocTypeGridEditor.Helpers
 
             // Get the current request node we are embedded in
 
-            var pcr = _umbracoContext.UmbracoContext.PublishedRequest;
+            var pcr = _umbracoContext.GetRequiredUmbracoContext().PublishedRequest;
             var containerNode = pcr != null && pcr.HasPublishedContent() ? pcr.PublishedContent : null;
 
             // Create the model based on our implementation of IPublishedElement

--- a/src/Our.Umbraco.DocTypeGridEditor/Our.Umbraco.DocTypeGridEditor.csproj
+++ b/src/Our.Umbraco.DocTypeGridEditor/Our.Umbraco.DocTypeGridEditor.csproj
@@ -16,8 +16,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Umbraco.Cms.Web.Website" Version="9.0.0-beta003" />
-        <PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="9.0.0-beta003" />
+        <PackageReference Include="Umbraco.Cms.Web.Website" Version="9.0.0-rc002" />
+        <PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="9.0.0-rc002" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Our.Umbraco.DocTypeGridEditor/Our.Umbraco.DocTypeGridEditor.csproj
+++ b/src/Our.Umbraco.DocTypeGridEditor/Our.Umbraco.DocTypeGridEditor.csproj
@@ -8,7 +8,7 @@
         <Product>Our.Umbraco.DocTypeGridEditor</Product>
         <PackageTags>umbraco plugin package</PackageTags>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>9.0.0-beta001</Version>
+        <Version>9.0.0-beta002</Version>
         <Authors>Søren Kottal</Authors>
         <Company></Company>
         <AssemblyName>Our.Umbraco.DocTypeGridEditor</AssemblyName>

--- a/src/Our.Umbraco.DocTypeGridEditor/ValueProcessing/Collections/DocTypeGridEditorValueProcessorsCollection.cs
+++ b/src/Our.Umbraco.DocTypeGridEditor/ValueProcessing/Collections/DocTypeGridEditorValueProcessorsCollection.cs
@@ -12,7 +12,7 @@ namespace Our.Umbraco.DocTypeGridEditor.ValueProcessing.Collections
     /// </summary>
     public class DocTypeGridEditorValueProcessorsCollection : BuilderCollectionBase<IDocTypeGridEditorValueProcessor>
     {
-        public DocTypeGridEditorValueProcessorsCollection(IEnumerable<IDocTypeGridEditorValueProcessor> items) : base(items)
+        public DocTypeGridEditorValueProcessorsCollection(Func<IEnumerable<IDocTypeGridEditorValueProcessor>> items) : base(items)
         {
 
         }


### PR DESCRIPTION
Update _umbracoContext.UmbracoContext  to _umbracoContext.GetRequiredUmbracoContext()
use DI for IVariationContextAccessor rather than removed _umbracoContext.UmbracoContext.VariationContextAccessor
BuilderCollectionBase consructor now expects Func<IEnumerable<TItem>> for paramaterless constructor support.
