### PR TITLE
Unable to save a component which previously failed validation

### DIFF
--- a/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.controllers.js
+++ b/src/Our.Umbraco.DocTypeGridEditor/Web/UI/App_Plugins/DocTypeGridEditor/Js/doctypegrideditor.controllers.js
@@ -267,6 +267,7 @@ angular.module("umbraco").controller("Our.Umbraco.DocTypeGridEditor.Dialogs.DocT
 
             function submit() {
                 if ($scope.model.submit) {
+                    serverValidationManager.reset();
                     vm.saveButtonState = "busy";
                     $scope.model.node.name = "Dtge Temp: " + $scope.model.node.key;
                     $scope.model.node.variants[0].name = $scope.model.node.name


### PR DESCRIPTION
Resets the serverside validation when a complex editor, like NestedContent, is not validated properly the first time.